### PR TITLE
fix: add missing lines

### DIFF
--- a/eval.lisp
+++ b/eval.lisp
@@ -38,7 +38,7 @@
             ((label evcond
                 (lambda (u a)
                  (cond ((eval (caar u) a)
-                     ((eval (cadar u) a))
+                        (eval (cadar u) a))
                      (t (evcond (cdr u) a)))))
                 (cdr e) a))
             (t (eval (cons (cdr ((label assoc
@@ -64,7 +64,7 @@
                      (t (cons (cons (car u) (car v))
                          (pairup (cdr u) (cdr v)))))))
               (cadar e)
-             (label evlis
+             ((label evlis
                  (lambda (u a)
                   (cond ((null u) nil)
                      (t (cons (eval (car u) a)

--- a/eval.lisp
+++ b/eval.lisp
@@ -73,4 +73,5 @@
              a))
             a)))
         ((eq (caar e) (quote label))
-         (eval (cons (caddar e) (cdr e))) a)))))
+         (eval (cons (caddar e) (cdr e))
+             (cons (cons (cadar e) (car e)) a))))))

--- a/eval.lisp
+++ b/eval.lisp
@@ -63,7 +63,7 @@
                   (cond ((null u) nil)
                      (t (cons (cons (car u) (car v))
                          (pairup (cdr u) (cdr v)))))))
-
+              (cadar e)
              (label evlis
                  (lambda (u a)
                   (cond ((null u) nil)

--- a/eval.lisp
+++ b/eval.lisp
@@ -6,8 +6,8 @@
            (t (cdr ((label assoc
                    (lambda (e a)
                     (cond ((null a) nil)
-                       ((eq e caar a)) (car a)
-                       (t (assoc e (cdr a)))))
+                       ((eq e (caar a)) (car a))
+                       (t (assoc e (cdr a))))))
                    e
                    a)))))
         ((atom (car e))


### PR DESCRIPTION
This PR adds two missing lines.
 - The call to `pairup` is missing the argument for the formal parameters, `(cadar e)`, on line 66.
 - On the final line, eval must be called with two arguments: the expression and the association list. The final line is missing a closing parenthesis in the original document to match the initial opening parenthesis.

It also fixes various misplaced parentheses.
 - In the first implementation of `assoc`, the call to `caar` on line 9 is missing an opening parenthesis. A closing parenthesis is also missing on that line.
 - A closing parenthesis is missing on line 10.
 - In `evcond` there is an extra opening parentheis on line 41.
 - An opening parenthesis is missing before the definition of `evlis` on line 67.